### PR TITLE
OPENSOURCE: Add notice for CC-BY-3.0 and CC-BY-4.0 dependencies

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,4 +2,4 @@ This project is based on open source software for which an additional notice is 
 
 The dependency spdx-exceptions.json by Kyle Mitchell is controlled by the package manager NPM and is licensed under CC-BY-3.0 (https://creativecommons.org/licenses/by/3.0/legalcode). Its source code can be obtained here: https://github.com/jslicense/spdx-exceptions.json
 
-The dependency caniuse-lite from caniuse.com is controlled by the package managed NPM and is licensed under CC-BY-4.0 (https://creativecommons.org/licenses/by/4.0/legalcode). Its source code can be obtained here: https://github.com/browserslist/caniuse-lite
+The dependency caniuse-lite from caniuse.com is controlled by the package manager NPM and is licensed under CC-BY-4.0 (https://creativecommons.org/licenses/by/4.0/legalcode). Its source code can be obtained here: https://github.com/browserslist/caniuse-lite

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+This project is based on open source software for which an additional notice is required.
+
+The dependency spdx-exceptions.json by Kyle Mitchell is controlled by the package manager NPM and is licensed under CC-BY-3.0 (https://creativecommons.org/licenses/by/3.0/legalcode). Its source code can be obtained here: https://github.com/jslicense/spdx-exceptions.json
+
+The dependency caniuse-lite from caniuse.com is controlled by the package managed NPM and is licensed under CC-BY-4.0 (https://creativecommons.org/licenses/by/4.0/legalcode). Its source code can be obtained here: https://github.com/browserslist/caniuse-lite


### PR DESCRIPTION
Dependencies being licensed with the CC-BY-3.0 and CC-BY-4.0 license need to have an additional notice in order to be legally compliant. This repository is affected because of spdx-exceptions and caniuse-lite.